### PR TITLE
feat: allow for parsing errors without crashing execution

### DIFF
--- a/examples/2_custom_evaluation_criteria.ipynb
+++ b/examples/2_custom_evaluation_criteria.ipynb
@@ -104,18 +104,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO 09-20 15:53:15 awq_marlin.py:89] The model is convertible to awq_marlin during runtime. Using awq_marlin kernel.\n",
-      "WARNING 09-20 15:53:15 config.py:378] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used\n",
-      "INFO 09-20 15:53:15 llm_engine.py:213] Initializing an LLM engine (v0.6.0) with config: model='flowaicom/Flow-Judge-v0.1-AWQ', speculative_config=None, tokenizer='flowaicom/Flow-Judge-v0.1-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=awq_marlin, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=flowaicom/Flow-Judge-v0.1-AWQ, use_v2_block_manager=False, num_scheduler_steps=1, enable_prefix_caching=False, use_async_output_proc=False)\n",
-      "INFO 09-20 15:53:15 model_runner.py:915] Starting to load model flowaicom/Flow-Judge-v0.1-AWQ...\n",
-      "INFO 09-20 15:53:16 weight_utils.py:236] Using model weights format ['*.safetensors']\n",
-      "INFO 09-20 15:53:16 weight_utils.py:280] No model.safetensors.index.json found in remote.\n"
+      "INFO 09-24 11:16:28 awq_marlin.py:89] The model is convertible to awq_marlin during runtime. Using awq_marlin kernel.\n",
+      "WARNING 09-24 11:16:28 config.py:383] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used\n",
+      "INFO 09-24 11:16:28 llm_engine.py:223] Initializing an LLM engine (v0.6.1.post2) with config: model='flowaicom/Flow-Judge-v0.1-AWQ', speculative_config=None, tokenizer='flowaicom/Flow-Judge-v0.1-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=awq_marlin, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=flowaicom/Flow-Judge-v0.1-AWQ, use_v2_block_manager=False, num_scheduler_steps=1, enable_prefix_caching=False, use_async_output_proc=False)\n",
+      "INFO 09-24 11:16:28 model_runner.py:997] Starting to load model flowaicom/Flow-Judge-v0.1-AWQ...\n",
+      "INFO 09-24 11:16:29 weight_utils.py:242] Using model weights format ['*.safetensors']\n",
+      "INFO 09-24 11:16:29 weight_utils.py:287] No model.safetensors.index.json found in remote.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "517b66e895064f31b014f0c18d8cd09e",
+       "model_id": "f7f2d7a078824faf890039eb8cdfb263",
        "version_major": 2,
        "version_minor": 0
       },
@@ -130,8 +130,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO 09-20 15:53:17 model_runner.py:926] Loading model weights took 2.1861 GB\n",
-      "INFO 09-20 15:53:19 gpu_executor.py:122] # GPU blocks: 3080, # CPU blocks: 682\n"
+      "INFO 09-24 11:16:30 model_runner.py:1008] Loading model weights took 2.1861 GB\n",
+      "INFO 09-24 11:16:31 gpu_executor.py:122] # GPU blocks: 3085, # CPU blocks: 682\n"
      ]
     }
    ],
@@ -148,14 +148,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processed prompts: 100%|██████████| 1/1 [00:07<00:00,  7.44s/it, est. speed input: 132.19 toks/s, output: 47.87 toks/s]\n"
+      "Processed prompts: 100%|██████████| 1/1 [00:06<00:00,  6.48s/it, est. speed input: 152.88 toks/s, output: 44.78 toks/s]\n"
      ]
     }
    ],
@@ -163,7 +163,7 @@
     "# Sample to evaluate\n",
     "\n",
     "query = \"I placed an order for a custom-built gaming PC (order #AC-789012) two weeks ago, but the estimated delivery date has changed twice since then. Originally it was supposed to arrive yesterday, then it got pushed to next week, and now the tracking page shows 'Status: Processing' with no delivery estimate at all. I've tried calling customer service, but after waiting on hold for an hour, I was told to check the website. Can you please look into this and explain what's causing the delays, when I can realistically expect my order to arrive, and whether I'm eligible for any kind of compensation or expedited shipping given these repeated delays? I'm especially concerned because I need this computer for an upcoming gaming tournament I'm participating in next month.\"\n",
-    "sub_queries = \"What is the current shipping status of my order? When will my computer arrive?\"\n",
+    "sub_queries = \"What is the current shipping status of my order? How can I build a PC?\"\n",
     "\n",
     "# bad decomposition\n",
     "eval_input = EvalInput(\n",
@@ -179,25 +179,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
        "__Feedback:__\n",
-       "The generated sub-queries demonstrate excellent breadth and effectively cover all major aspects of the main query. The first sub-query, \"What is the current shipping status of my order?\" directly addresses the customer's concern about the changing delivery dates and the current 'Status: Processing' message on the tracking page. This sub-query ensures that the customer's immediate concern about the order's location is addressed.\n",
+       "The generated sub-queries fail to provide sufficient breadth to cover all aspects of the main query. The main query addresses multiple issues: repeated delivery date changes, current shipping status, potential compensation, and expedited shipping options. However, the sub-queries only touch on two narrow aspects: the current shipping status and how to build a PC.\n",
        "\n",
-       "The second sub-query, \"When will my computer arrive?\" tackles the customer's request for a realistic delivery estimate, which is crucial given the repeated delays and the customer's urgent need for the gaming PC. This sub-query aims to provide the specific information the customer is seeking regarding the expected arrival time of their order.\n",
+       "The sub-queries completely miss several critical elements of the main query:\n",
+       "1. The reason for repeated delivery date changes\n",
+       "2. The current status of the order\n",
+       "3. Eligibility for compensation\n",
+       "4. Options for expedited shipping\n",
+       "5. The impact on the upcoming gaming tournament\n",
        "\n",
-       "Furthermore, the sub-queries implicitly cover the customer's concern about potential compensation or expedited shipping by addressing the current status and expected delivery time. While not explicitly mentioned, these aspects are inherently part of understanding the order's status and delivery timeline.\n",
+       "By focusing only on the current shipping status and PC building, the sub-queries significantly limit the scope of the investigation. They fail to address the customer's concerns about repeated delays, potential compensation, and the urgency of the situation due to the upcoming gaming tournament.\n",
        "\n",
-       "The sub-queries also touch on the customer's need for the computer for an upcoming gaming tournament, as addressing the delivery status and providing a realistic arrival time would be directly relevant to the customer's situation.\n",
-       "\n",
-       "Overall, the sub-queries break down the main question into a diverse set of dimensions, ensuring a comprehensive exploration of the topic. Each significant facet of the main query is represented, allowing for a thorough and well-rounded investigation of the subject matter.\n",
+       "Using these sub-queries alone would result in a severely limited exploration of the topic, failing to address the majority of the customer's concerns and questions. The sub-queries do not provide a comprehensive breakdown of the main query's dimensions, leaving many important aspects unexplored.\n",
        "\n",
        "__Score:__\n",
-       "3"
+       "1"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -214,14 +217,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processed prompts: 100%|██████████| 1/1 [00:06<00:00,  6.74s/it, est. speed input: 175.59 toks/s, output: 46.46 toks/s]\n"
+      "Processed prompts: 100%|██████████| 1/1 [00:07<00:00,  7.21s/it, est. speed input: 164.03 toks/s, output: 45.93 toks/s]\n"
      ]
     }
    ],
@@ -250,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -264,15 +267,17 @@
        "1. Current status and reasons for delivery date changes\n",
        "2. Specific factors causing delays\n",
        "3. Realistic expected delivery time\n",
-       "4. Compensation options due to delays\n",
-       "5. Availability of expedited shipping\n",
-       "6. Prioritization of the order considering the upcoming tournament\n",
-       "7. Actions taken by customer service and potential additional steps\n",
-       "8. Improved communication and updates for the customer\n",
+       "4. Compensation options\n",
+       "5. Expedited shipping options\n",
+       "6. Prioritization of urgency\n",
+       "7. Actions taken by customer service\n",
+       "8. Future updates on order status\n",
        "\n",
-       "These sub-queries break down the main question into diverse dimensions, ensuring a thorough investigation of the subject matter. They cover the technical aspects of the order, the customer service response, potential solutions, and future improvements. This comprehensive approach allows for a well-rounded exploration of the topic, addressing all major concerns raised in the original query.\n",
+       "These sub-queries break down the main question into diverse dimensions, ensuring a thorough investigation of the subject matter. They cover the customer's concerns about delays, compensation, and the urgency of their order, as well as potential solutions like expedited shipping. Additionally, they address the need for better communication and updates from the company.\n",
        "\n",
-       "The sub-queries are well-structured and cover all important aspects without straying from the main query's intent. They provide a solid foundation for investigating and resolving the customer's issues, ensuring that no significant part of the original query is overlooked.\n",
+       "The sub-queries are well-structured and cover all major aspects of the customer's query, providing a comprehensive framework for addressing the issues raised. This thorough approach ensures that all relevant information is considered and that the customer's concerns are fully explored.\n",
+       "\n",
+       "Overall, the sub-queries demonstrate excellent breadth and depth, effectively covering all major aspects of the main query and providing a solid foundation for a comprehensive investigation of the topic.\n",
        "\n",
        "__Score:__\n",
        "3"
@@ -292,27 +297,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Processed prompts: 100%|██████████| 1/1 [00:06<00:00,  6.70s/it, est. speed input: 158.41 toks/s, output: 45.84 toks/s]\n"
+      "Processed prompts: 100%|██████████| 1/1 [00:08<00:00,  8.10s/it, est. speed input: 130.86 toks/s, output: 43.09 toks/s]\n"
      ]
     },
     {
      "data": {
       "text/markdown": [
        "__Feedback:__\n",
-       "The generated sub-queries demonstrate a good attempt to cover various aspects of the main query, but they fall short of providing comprehensive breadth. The sub-queries address several key points raised in the main query, such as the current status of the order, reasons for delivery date changes, expected arrival time, and the possibility of expediting the order. These are directly relevant to the customer's concerns.\n",
+       "The generated sub-queries demonstrate a good attempt to cover various aspects of the main query, but they fall short of achieving excellent breadth. \n",
        "\n",
-       "However, there are noticeable gaps in coverage. The sub-queries fail to address the customer's repeated attempts to contact customer service and the specific instructions given by customer service. They also don't address the customer's concern about eligibility for compensation due to repeated delays. While the sub-queries do touch on the need for better customer service support, they don't specifically address the customer's frustration with the support experience.\n",
+       "The sub-queries address several key points from the main query:\n",
+       "1. The current status of the order (sub-query 1)\n",
+       "2. The reason for multiple delivery date changes (sub-query 2)\n",
+       "3. The expected arrival time of the order (sub-query 3)\n",
+       "4. The possibility of expediting the order (sub-query 8)\n",
        "\n",
-       "Additionally, the sub-queries include some that are not directly relevant to the main query, such as questions about store hours and the name of the person responsible for the company. These do not contribute to addressing the customer's specific concerns about the order and its delays.\n",
+       "These sub-queries effectively cover the main concerns about order status, delivery delays, and potential solutions.\n",
        "\n",
-       "Overall, while the sub-queries cover some important aspects of the main query, they miss several key points and include some irrelevant questions, preventing a truly comprehensive exploration of the topic.\n",
+       "However, there are noticeable gaps in coverage:\n",
+       "- The sub-queries don't address the customer's experience with customer service, which was a significant part of the original query.\n",
+       "- There's no sub-query specifically about compensation for the repeated delays, which was another key concern in the main query.\n",
+       "- The sub-queries don't address the urgency of the situation due to the upcoming gaming tournament, which was mentioned in the main query.\n",
+       "\n",
+       "While the sub-queries do a good job of breaking down the main query into several dimensions, they miss some important facets. Answering these sub-queries would provide a partial exploration of the main topic, but not a comprehensive one.\n",
+       "\n",
+       "Therefore, based on the evaluation criteria and scoring rubric, the sub-queries should be rated as:\n",
+       "\n",
+       "<score>\n",
+       "2\n",
+       "</score>\n",
        "\n",
        "__Score:__\n",
        "2"
@@ -349,6 +369,13 @@
     "# Display the result\n",
     "display(Markdown(f\"__Feedback:__\\n{result.feedback}\\n\\n__Score:__\\n{result.score}\"))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_flow_judge.py
+++ b/tests/test_flow_judge.py
@@ -141,17 +141,6 @@ def test_eval_input_validation(mock_model):
         judge.evaluate(invalid_output)
 
 
-def test_eval_output_parsing():
-    """Test EvalOutput parsing."""
-    valid_response = "<feedback>Test feedback</feedback>\n<score>1</score>"
-    parsed = EvalOutput.parse(valid_response)
-    assert parsed.feedback == "Test feedback"
-    assert parsed.score == 1
-
-    with pytest.raises(ValueError):
-        EvalOutput.parse("Invalid response")
-
-
 def test_format_vars():
     """Test format_vars function."""
     variables = [{"question": "What is 2+2?"}, {"context": "Math basics"}]
@@ -191,6 +180,29 @@ def test_format_prompt(mock_model):
         RUBRIC=format_rubric(RESPONSE_CORRECTNESS_BINARY.rubric),
     )
     assert prompt == expected_prompt
+
+
+def test_eval_output_parse_fail_on_parse_error():
+    """Test EvalOutput.parse with fail_on_parse_error."""
+    # Invalid response without proper tags
+    invalid_response = "This is an invalid response without proper tags"
+
+    # Test with fail_on_parse_error=False (default behavior)
+    result = EvalOutput.parse(invalid_response)
+    assert isinstance(result, EvalOutput)
+    assert result.feedback == "Error"
+    assert result.score == -1
+
+    # Test with fail_on_parse_error=True
+    with pytest.raises(ValueError):
+        EvalOutput.parse(invalid_response, fail_on_parse_error=True)
+
+    # Test with valid response
+    valid_response = "<feedback>Good job!</feedback><score>5</score>"
+    result = EvalOutput.parse(valid_response)
+    assert isinstance(result, EvalOutput)
+    assert result.feedback == "Good job!"
+    assert result.score == 5
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description
This PR modifies the `EvalOutput` parser method to include a new `fail_on_parse_error` argument, which controls the behavior when an output cannot be parsed into a score and feedback. This change primarily affects the `batch_evaluate` method of `FlowJudge` classes.

## Key changes
- Added `fail_on_parse_error` argument to the EvalOutput parser method
- Defaults to `False` to prevent `batch_evaluate` from crashing
- When `False`, sets default feedback to `"Error"` and score to `-1` for unparseable outputs. Still writes them in results.
- Implemented logging for the number of parsing errors encountered
- Added a unit test to cover the new functionality
- Manually tested with various valid and invalid options