### PR TITLE
langchain integration and tutorial

### DIFF
--- a/examples/6_langchain_evaluators.ipynb
+++ b/examples/6_langchain_evaluators.ipynb
@@ -139,7 +139,7 @@
     "2. **Flow-Judge Custom Metric**:\n",
     "   As an alternative, we'll demonstrate how to use Flow-Judge to create a custom metric for evaluating helpfulness. Our custom metric will use a binary scale, offering a straightforward yet effective way to gauge response quality.\n",
     "\n",
-    "By comparing these two methods, we'll gain insights into the flexibility and capabilities of both LangChain and Flow-Judge for assessing AI model outputs.\n",
+    "By comparing these two methods, we'll gain insights into the flexibility and capabilities of both LangChain and Flow-Judge for assessing LLM outputs.\n",
     "\n",
     "Let's dive in and see how these evaluators perform in practice!"
    ]
@@ -235,11 +235,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This evaluation example of the off-the-shelf LangChain evaluator for helpfulness uses gpt-4 to rate the response. It provides a score of 1 which is correct in this case. The reasoning is also provided but it's rather lengthy.  \n",
+    "This evaluation example of the off-the-shelf LangChain evaluator for helpfulness uses gpt-4 to rate the response. It provides a score of 1 which is correct in this case. The reasoning is also provided. While gpt-4 is a powerful evaluator due to cost and privacy concerns it's not always feasible to use it for evaluations. \n",
     "\n",
     "Now let's see how we can use the `FlowJudgeLangChainEvaluator` to achieve the same result by using the flow-judge model to rate the example.  \n",
     "\n",
-    "We will first create a custom metric for helpfulness. For this example we will use a binary scale to rate the response as helpful or not. Custom metrics are customizable and can be used to evaluate responses based on specific criteria and scoring scales, which makes them a powerful tool for creating tailored evaluation pipelines.\n"
+    "We will first create a custom metric for helpfulness. For this example we will use a binary scale to rate the response as helpful or not. Custom metrics can be tailored to evaluate responses based on specific criteria and scoring scales, which makes them a powerful tool for creating use case specific evaluation pipelines. Please refer to the [custom metrics tutorial](2_custom_evaluation_criteria.ipynb) for more examples on how to create custom metrics. \n"
    ]
   },
   {
@@ -261,6 +261,18 @@
     "    required_inputs=[\"input\"], # We will use variable input as it's the standard format for LangChain evaluators. \n",
     "    required_output=\"prediction\" # We will use variable prediction as it's the standard format for LangChain evaluators. It's also a required fiel\n",
     ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Note:** Langchain evaluators typically use the following input variables in their evaluations:  \n",
+    "> - `prediction`: The LLM's response. This is always required\n",
+    "> - `input`: The user's query. This is optional.\n",
+    "> - `reference`: The reference answer to the query. Some of the evaluators also map context to the reference variable.This is optional. \n",
+    ">\n",
+    ">Flow Judge metrics have required inputs and outputs. In order to keep the approach consistent with Langchain the output/response should always be assigned to the `prediction` variable. FlowJudgeLangChainEvaluator will map the prediction correctly to the required output of the metric. The inputs are optional and should be mapped to the required inputs of the metric. \n"
    ]
   },
   {

--- a/examples/6_langchain_evaluators.ipynb
+++ b/examples/6_langchain_evaluators.ipynb
@@ -1,0 +1,599 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Flow Judge with Langchain Evaluators\n",
+    "\n",
+    "## Introduction to Flow Judge and LangChain Integration\n",
+    "\n",
+    "Flow Judge is an open-source language model optimized for evaluating AI systems. This tutorial demonstrates how to integrate Flow Judge with LangChain. By the end of this notebook, you'll understand how to create custom metrics, run evaluations, and analyze results using both Flow Judge and LangChain tools.  \n",
+    "\n",
+    "A key component of this integration is the custom `FlowJudgeLangChainEvaluator` class we created. This class extends LangChain's `StringEvaluator`, allowing Flow Judge to be seamlessly integrated into LangChain workflows. By implementing this custom evaluator, we can use Flow Judge metrics in the same way as LangChain's built-in evaluators, making it easy to incorporate Flow Judge's capabilities into existing LangChain-based evaluation pipelines.\n",
+    "\n",
+    "With the `FlowJudgeLangChainEvaluator`, we can easily integrate Flow Judge into LangChain workflow, combining the flexibility and power of Flow Judge's custom metrics with the convenience and standardization of LangChain's framework.\n",
+    "\n",
+    "\n",
+    "## `Flow-Judge-v0.1`\n",
+    "\n",
+    "`Flow-Judge-v0.1` is an open-source, lightweight (3.8B) language model optimized for LLM system evaluations. Crafted for accuracy, speed, and customization.\n",
+    "\n",
+    "Read the technical report [here](https://www.flow-ai.com/blog/flow-judge).\n",
+    "\n",
+    "\n",
+    "## LangChain evaluators\n",
+    "\n",
+    "LangChain is a powerful framework for developing applications using large language models.\n",
+    "\n",
+    "Refer to the [LangChain evaluation module API reference](https://python.langchain.com/v0.2/api_reference/langchain/evaluation.html#) for more detailed information about their evaluation module.\n",
+    " \n",
+    "LangChain's evaluation module offers built-in evaluators for evaluating the outputs of chains and LLMs.\n",
+    "\n",
+    "In this notebook, we will demonstrate how to utilize `Flow-Judge-v0.1` custom metrics together with LangChain's framework.\n",
+    "\n",
+    "## System Requirements\n",
+    "\n",
+    "Flow Judge requires a GPU with at least 2.3GB of VRAM. If you're using a non-Ampere GPU, please use the `Flow-Judge-v0.1_HF_no_flsh_attn` model instead of the default one.\n",
+    "\n",
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install langchain langchain_openai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenAI API key\n",
+    "\n",
+    "You need to provide an OpenAI API key to use the Langchain evaluators with gpt-4. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-..\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model\n",
+    "\n",
+    "For this tutorial, we are going to use the quantized version of `Flow-Judge-v0.1`. Under the hood, `flow-judge` uses the vLLM engine to run the model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 10-07 12:20:30 awq_marlin.py:89] The model is convertible to awq_marlin during runtime. Using awq_marlin kernel.\n",
+      "WARNING 10-07 12:20:30 config.py:378] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used\n",
+      "INFO 10-07 12:20:30 llm_engine.py:213] Initializing an LLM engine (v0.6.0) with config: model='flowaicom/Flow-Judge-v0.1-AWQ', speculative_config=None, tokenizer='flowaicom/Flow-Judge-v0.1-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=awq_marlin, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=flowaicom/Flow-Judge-v0.1-AWQ, use_v2_block_manager=False, num_scheduler_steps=1, enable_prefix_caching=False, use_async_output_proc=False)\n",
+      "INFO 10-07 12:20:31 model_runner.py:915] Starting to load model flowaicom/Flow-Judge-v0.1-AWQ...\n",
+      "INFO 10-07 12:20:31 weight_utils.py:236] Using model weights format ['*.safetensors']\n",
+      "INFO 10-07 12:20:31 weight_utils.py:280] No model.safetensors.index.json found in remote.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8746adec876e49fcaac4164782ade6ce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 10-07 12:20:32 model_runner.py:926] Loading model weights took 2.1861 GB\n",
+      "INFO 10-07 12:20:33 gpu_executor.py:122] # GPU blocks: 2442, # CPU blocks: 682\n"
+     ]
+    }
+   ],
+   "source": [
+    "from flow_judge.models.model_factory import ModelFactory\n",
+    "\n",
+    "model = ModelFactory.create_model(\"Flow-Judge-v0.1-AWQ\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Criteria Based Evaluation \n",
+    "\n",
+    "### Comparing LangChain and Flow-Judge Evaluators\n",
+    "\n",
+    "In this example, we'll explore two different approaches to evaluating the helpfulness of AI-generated responses:\n",
+    "\n",
+    "1. **LangChain's Criteria-Based Evaluator**: \n",
+    "   LangChain provides a built-in evaluator specifically designed to assess responses based on specific criteria. In this example, we'll use the \"helpfulness\" criteria.\n",
+    "\n",
+    "2. **Flow-Judge Custom Metric**:\n",
+    "   As an alternative, we'll demonstrate how to use Flow-Judge to create a custom metric for evaluating helpfulness. Our custom metric will use a binary scale, offering a straightforward yet effective way to gauge response quality.\n",
+    "\n",
+    "By comparing these two methods, we'll gain insights into the flexibility and capabilities of both LangChain and Flow-Judge for assessing AI model outputs.\n",
+    "\n",
+    "Let's dive in and see how these evaluators perform in practice!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example query and responses for evaluating helpfulness with LangChain\n",
+    "\n",
+    "query = \"I'm having trouble logging into my account. What should I do?\"\n",
+    "\n",
+    "response = '''I'm sorry to hear you're having trouble logging in. Here are some steps you can try:\n",
+    "\n",
+    "1. Double-check that you're using the correct email address and password.\n",
+    "2. If you've forgotten your password, click on the 'Forgot Password' link on the login page to reset it.\n",
+    "3. Clear your browser's cache and cookies, then try logging in again.\n",
+    "4. Make sure your internet connection is stable.\n",
+    "5. If you're still having issues, please provide me with the error message you're seeing, or any specific problems you encounter during the login process.\n",
+    "\n",
+    "If none of these steps work, I'd be happy to escalate this to our technical support team. They can take a closer look at your account and help resolve any underlying issues.'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Score:** 1"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Reasoning:** The criterion for this task is helpfulness. The submission should be helpful, insightful, and appropriate.\n",
+       "\n",
+       "Looking at the submission, it provides a detailed step-by-step guide on what the user can do if they're having trouble logging into their account. It starts by suggesting the user to double-check their login credentials, which is a common issue when users have trouble logging in. This is helpful and appropriate.\n",
+       "\n",
+       "Next, it suggests the user to use the 'Forgot Password' feature if they've forgotten their password. This is also helpful and appropriate, as it's a common feature on most login pages.\n",
+       "\n",
+       "The submission then suggests clearing the browser's cache and cookies, and ensuring a stable internet connection. These are insightful suggestions, as they might not be the first things a user thinks of when they're having trouble logging in.\n",
+       "\n",
+       "Finally, the submission offers to escalate the issue to the technical support team if none of the suggested steps work. This is helpful, as it assures the user that further assistance is available if needed.\n",
+       "\n",
+       "Based on this analysis, the submission is helpful, insightful, and appropriate. It provides a comprehensive guide on what to do when having trouble logging in, and offers further assistance if needed.\n",
+       "\n",
+       "Y"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "from langchain.evaluation import load_evaluator\n",
+    "\n",
+    "evaluator = load_evaluator(\"criteria\", criteria=\"helpfulness\")\n",
+    "\n",
+    "# This evaluation will use gpt-4 to evaluate the response. \n",
+    "eval_result = evaluator.evaluate_strings(\n",
+    "    prediction=response,\n",
+    "    input=query\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"**Score:** {eval_result[\"score\"]}\"))\n",
+    "display(Markdown(f\"**Reasoning:** {eval_result[\"reasoning\"]}\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This evaluation example of the off-the-shelf LangChain evaluator for helpfulness uses gpt-4 to rate the response. It provides a score of 1 which is correct in this case. The reasoning is also provided but it's rather lengthy.  \n",
+    "\n",
+    "Now let's see how we can use the `FlowJudgeLangChainEvaluator` to achieve the same result by using the flow-judge model to rate the example.  \n",
+    "\n",
+    "We will first create a custom metric for helpfulness. For this example we will use a binary scale to rate the response as helpful or not. Custom metrics are customizable and can be used to evaluate responses based on specific criteria and scoring scales, which makes them a powerful tool for creating tailored evaluation pipelines.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flow_judge.metrics import CustomMetric, RubricItem\n",
+    "\n",
+    "# Define a binary helpfulness metric\n",
+    "helpfulness_metric = CustomMetric(\n",
+    "    name=\"binary_helpfulness\",\n",
+    "    criteria=\"Evaluate if the response is helpful in addressing the user's query\",\n",
+    "    rubric=[\n",
+    "        RubricItem(score=0, description=\"The response is not helpful in addressing the user's query.\"),\n",
+    "        RubricItem(score=1, description=\"The response is helpful in addressing the user's query.\")\n",
+    "    ],\n",
+    "    required_inputs=[\"input\"], # We will use variable input as it's the standard format for LangChain evaluators. \n",
+    "    required_output=\"prediction\" # We will use variable prediction as it's the standard format for LangChain evaluators. It's also a required fiel\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.85s/it, est. speed input: 413.91 toks/s, output: 69.61 toks/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Score:** 1"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Reasoning:** The response provided is highly helpful in addressing the user's query about trouble logging into their account. It offers a clear, step-by-step approach to troubleshoot the issue, covering common problems such as incorrect login credentials, forgotten passwords, and technical issues like browser cache and internet connection. Additionally, it provides an option to escalate the issue to technical support if the suggested steps do not resolve the problem. This comprehensive and user-friendly approach effectively addresses the user's concern and provides actionable solutions."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from flow_judge.integrations.langchain import FlowJudgeLangChainEvaluator\n",
+    "\n",
+    "helpfulness_evaluator = FlowJudgeLangChainEvaluator(metric=helpfulness_metric, model=model)\n",
+    "\n",
+    "eval_result = helpfulness_evaluator.evaluate_strings(\n",
+    "    prediction=response,\n",
+    "    input=query\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"**Score:** {eval_result[\"score\"]}\"))\n",
+    "display(Markdown(f\"**Reasoning:** {eval_result[\"reasoning\"]}\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have now demonstrated how to use the `FlowJudgeLangChainEvaluator` to evaluate the same example response using a custom metric.  \n",
+    "\n",
+    "Next let's take a look at a different example for evaluation the correctness of QA examples based on context. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## QA Evaluations\n",
+    "\n",
+    "In this example, we compare two approaches for evaluating question-answering (QA) responses:\n",
+    "\n",
+    "1. **LangChain's Context QA Evaluator**\n",
+    "2. **Flow-Judge Custom QA Metric**\n",
+    "\n",
+    "### LangChain QA Evaluation\n",
+    "\n",
+    "LangChain's built-in \"context_qa\" evaluator provides a binary assessment:\n",
+    "\n",
+    "- Score: CORRECT/INCORRECT\n",
+    "- Reasoning: Brief explanation of the judgment\n",
+    "\n",
+    "### Flow-Judge QA Evaluation\n",
+    "\n",
+    "Our custom Flow-Judge metric offers a more nuanced evaluation:\n",
+    "\n",
+    "- Score: 1-3 scale\n",
+    "   - 1: Incorrect or missing most key points\n",
+    "   - 2: Partially correct with some missing information or minor inaccuracies\n",
+    "   - 3: Fully correct and complete\n",
+    "- Reasoning: Detailed explanation of the score and how well the response aligns with the reference answer\n",
+    "\n",
+    "### Comparison\n",
+    "\n",
+    "Both evaluators assessed the correctness of the response in the context of the given query and reference answer. While LangChain provides a straightforward CORRECT/INCORRECT judgment, Flow-Judge offers a more granular assessment with its 1-3 scale.\n",
+    "\n",
+    "Key differences:\n",
+    "1. **Scoring granularity**: Flow-Judge's 3-point scale allows for more nuanced feedback compared to LangChain's binary output.\n",
+    "2. **Reasoning detail**: Flow-Judge typically provides more comprehensive explanations, which can be valuable for understanding subtle quality differences between responses.\n",
+    "3. **Customization**: The Flow-Judge metric can be easily adjusted to focus on specific aspects of QA performance, offering flexibility for various use cases.\n",
+    "\n",
+    "This comparison demonstrates how Flow-Judge can provide more detailed insights into response quality, which can be particularly useful for fine-tuning QA systems or conducting in-depth analyses of model outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Customer Service QA with Context\n",
+    "\n",
+    "# User Query\n",
+    "query = \"What can I do if I'm not happy with my new TechGadget Pro?\"\n",
+    "\n",
+    "# Context\n",
+    "context = \"\"\"\n",
+    "TechGadget Pro smartphone features:\n",
+    "- 6.5-inch OLED display, 5G capable\n",
+    "- 128GB or 256GB storage\n",
+    "- Triple camera system\n",
+    "- Water-resistant (IP68)\n",
+    "- Price starts at $799\n",
+    "\n",
+    "Return policy: 30-day full refund for undamaged products.\n",
+    "For software issues: Try restarting and updating before contacting support.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Customer Service Response\n",
+    "response = \"\"\"\n",
+    "I understand you're not satisfied with your TechGadget Pro. Here are some options for you:\n",
+    "1. You can return the device within 14 days for a full refund, as long as it's undamaged.\n",
+    "2. If you're experiencing software issues, try restarting the device and check for any available updates.\n",
+    "3. For hardware problems, please visit one of our authorized service centers.\n",
+    "4. We offer a trade-in program if you'd prefer to upgrade to a different model.\n",
+    "Could you tell me more about what specific issues you're facing with the TechGadget Pro?\n",
+    "\"\"\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### LangChain's Context QA Evaluator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Score:** 0"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Reasoning:** INCORRECT"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "qa_evaluator = load_evaluator(\"context_qa\")\n",
+    "\n",
+    "eval_result = qa_evaluator.evaluate_strings(\n",
+    "    prediction=response,\n",
+    "    input=query, \n",
+    "    reference=context # QA evalchain maps the reference as context\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"**Score:** {eval_result[\"score\"]}\"))\n",
+    "display(Markdown(f\"**Reasoning:** {eval_result[\"reasoning\"]}\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flow-Judge Custom QA Evaluator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correctness_metric = CustomMetric(\n",
+    "    name=\"context_correctness\",\n",
+    "    criteria=\"Evaluate the correctness of the response based on the given context\",\n",
+    "    rubric=[\n",
+    "        RubricItem(score=1, description=\"The response is mostly incorrect or contradicts the information in the context.\"),\n",
+    "        RubricItem(score=2, description=\"The response is partially correct but misses some key information from the context or contains minor inaccuracies.\"),\n",
+    "        RubricItem(score=3, description=\"The response is fully correct and accurately reflects the information provided in the context.\")\n",
+    "    ],\n",
+    "    required_inputs=[\"input\", \"context\"],\n",
+    "    required_output=\"prediction\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processed prompts: 100%|██████████| 1/1 [00:03<00:00,  3.19s/it, est. speed input: 276.10 toks/s, output: 71.45 toks/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Score:** 2"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Reasoning:** The response provided by the AI system is mostly correct but contains a significant inaccuracy that affects its overall score. \n",
+       "\n",
+       "1. The return policy is correctly stated as a 30-day full refund for undamaged products.\n",
+       "2. The suggestion to restart the device and check for updates is appropriate for software issues.\n",
+       "3. The advice to visit an authorized service center for hardware problems is also correct.\n",
+       "4. The mention of a trade-in program is not mentioned in the given context and is an additional option that was not provided.\n",
+       "\n",
+       "The main issue is the incorrect return period stated in the response. The context specifies a 30-day return policy, but the response incorrectly states a 14-day period. This is a critical error as it directly contradicts the information provided in the context.\n",
+       "\n",
+       "Given these points, the response is partially correct but misses some key information from the context and contains a significant inaccuracy."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "flow_judge_correctness_evaluator = FlowJudgeLangChainEvaluator(model=model, metric=correctness_metric)\n",
+    "\n",
+    "# Evaluate using Flow-Judge evaluator\n",
+    "correctness_result = flow_judge_correctness_evaluator.evaluate_strings(\n",
+    "    input=query,\n",
+    "    context=context,\n",
+    "    prediction=response\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"**Score:** {correctness_result[\"score\"]}\"))\n",
+    "display(Markdown(f\"**Reasoning:** {correctness_result[\"reasoning\"]}\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see the flow-judge evaluator provides a more detailed score and reasoning for the correctness of the response. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary \n",
+    "\n",
+    "This notebook demonstrated how to integrate Flow Judge with LangChain, combining the strengths of both frameworks. We showed how to create custom metrics using Flow Judge and seamlessly incorporate them into LangChain workflows. By comparing Flow Judge's approach with LangChain's built-in evaluators, we highlighted the benefits of using Flow Judge for more detailed and customizable insights into response quality.\n",
+    "\n",
+    "A key component of this integration is the custom `FlowJudgeLangChainEvaluator` class we created. This class allows Flow Judge to be easily integrated into existing LangChain pipelines, enabling users to leverage Flow Judge's powerful evaluation capabilities within the familiar LangChain ecosystem.\n",
+    "\n",
+    "By using Flow Judge within LangChain, developers can:\n",
+    "1. Create highly customized evaluation metrics tailored to specific use cases\n",
+    "2. Obtain more granular and detailed feedback on model outputs\n",
+    "3. Seamlessly incorporate Flow Judge's evaluation capabilities into existing LangChain-based projects\n",
+    "\n",
+    "This integration demonstrates how Flow Judge can enhance LangChain's functionality, providing users with more flexible and powerful tools for evaluating AI-generated responses."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "flow-eval-tutorials",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/flow_judge/integrations/langchain.py
+++ b/flow_judge/integrations/langchain.py
@@ -1,0 +1,110 @@
+from typing import Any, Dict, List, Optional, Union, Sequence
+from langchain.evaluation import StringEvaluator
+from flow_judge.models.model_factory import ModelFactory
+from flow_judge.models.base import BaseFlowJudgeModel, AsyncBaseFlowJudgeModel
+from flow_judge.flow_judge import EvalInput, FlowJudge, AsyncFlowJudge
+from flow_judge.metrics import Metric, CustomMetric 
+import asyncio
+
+class FlowJudgeLangChainEvaluator(StringEvaluator):
+
+    def __init__(
+        self, metric: Metric | CustomMetric, model: BaseFlowJudgeModel | AsyncBaseFlowJudgeModel
+    ):
+        """Initialize the LlamaIndexFlowJudge."""
+        if isinstance(metric, (Metric, CustomMetric)):
+            self.metric = metric
+        else:
+            raise ValueError("Invalid metric type. Use Metric or CustomMetric.")
+        # Validate model and choose appropriate FlowJudge class
+        if isinstance(model, (BaseFlowJudgeModel, AsyncBaseFlowJudgeModel)): 
+            self.model = model
+        else:
+            raise ValueError("The model must be an instance of BaseFlowJudgeModel or AsyncBaseFlowJudgeModel.")
+
+        # Initialize the appropriate judge based on the model type
+        if isinstance(self.model, AsyncBaseFlowJudgeModel):
+            self.judge = AsyncFlowJudge(metric=self.metric, model=self.model)
+        else:
+            self.judge = FlowJudge(metric=self.metric, model=self.model)
+
+    def _prepare_eval_input(
+        self,
+        prediction: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+        **kwargs: Any,
+    ) -> EvalInput:
+        # Combine all inputs into a single dictionary
+        all_inputs = {
+            "prediction": prediction,
+            "reference": reference,
+            "input": input,
+            **kwargs
+        }
+
+        # Prepare eval_inputs based on metric's required_inputs
+        eval_inputs = []
+        for req_input in self.metric.required_inputs:
+            if req_input in all_inputs:
+                value = all_inputs[req_input]
+                if isinstance(value, (list, Sequence)) and not isinstance(value, str):
+                    eval_inputs.extend([{req_input: v} for v in value])
+                else:
+                    eval_inputs.append({req_input: value})
+
+        # Prepare the output
+        output_key = self.metric.required_output
+        output_value = all_inputs.get(output_key, prediction)  # Default to prediction if not specified
+
+        return EvalInput(
+            inputs=eval_inputs,
+            output={output_key: output_value}
+        )
+
+    def _evaluate_strings(
+        self,
+        prediction: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        eval_input = self._prepare_eval_input(prediction, reference, input, **kwargs)
+        result = self.judge.evaluate(eval_input, save_results=False)
+        
+        return {
+            "score": result.score,
+            "reasoning": result.feedback,
+        } 
+        
+    async def _aevaluate_strings(
+        self,
+        prediction: str,
+        reference: Optional[str] = None,
+        input: Optional[str] = None, 
+        sleep_time_in_seconds: int = 1,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        await asyncio.sleep(sleep_time_in_seconds)
+        eval_input = self._prepare_eval_input(prediction, reference, input, **kwargs)
+        result = await self.judge.async_evaluate(eval_input, save_results=False)
+        
+        return {
+            "score": result.score,
+            "reasoning": result.feedback,
+        }
+
+    @property
+    def requires_input(self) -> bool:
+        return "input" in self.metric.required_inputs
+
+    @property
+    def requires_reference(self) -> bool:
+        return "reference" in self.metric.required_inputs
+
+    @property
+    def evaluation_name(self) -> str:
+        return f"flow_judge_{self.metric.name}"
+
+    def get_required_inputs(self) -> List[str]:
+        return self.metric.required_inputs + [self.metric.required_output]


### PR DESCRIPTION
# LangChain Integration for Flow Judge

## Summary
This PR introduces an integration between Flow Judge and LangChain, allowing users to leverage Flow Judge's custom metrics within LangChain workflows.

## Key Changes
1. Created `FlowJudgeLangChainEvaluator` class on the integrations folder: 
   - Extends LangChain's `StringEvaluator`
   - Enables use of Flow Judge metrics in LangChain pipelines

2. Added example notebook:
   - Demonstrates usage of Flow Judge integration within LangChain
   - Compares Flow Judge custom metrics with LangChain's built-in evaluators

## Testing
The integration has been manually tested: 
-  On linux Ubuntu 22.04.3 LTS 
- Verified functionality of `FlowJudgeLangChainEvaluator` with models Flow-Judge-v0.1-AWQ, Flow-Judge-v0.1, Flow-Judge-v0.1_HF and Flow-Judge-v0.1-AWQ-Async ( note Async functionality is not demonstrated in the notebook, but it was part of the standard stringevaluator class, so I added the option as well) 
- Verified functionality of `FlowJudgeLangChainEvaluator` with custom metric (in notebook), and built-in metrics (metric=RESPONSE_CORRECTNESS_BINARY, model=model)
- Tested integration in example notebook, ensuring correct behaviour within LangChain workflows
- Manually viewed results with LangChain's native evaluators to confirm accuracy and consistency
