### PR TITLE
hotfix: cover for download_dir being None

### DIFF
--- a/flow_judge/models/vllm.py
+++ b/flow_judge/models/vllm.py
@@ -195,11 +195,13 @@ class Vllm(BaseFlowJudgeModel, AsyncBaseFlowJudgeModel):
                 "gpu_memory_utilization": config.gpu_memory_utilization,
                 "max_num_seqs": config.max_num_seqs,
                 "quantization": "awq_marlin" if config.quantization else None,
-                "download_dir": download_dir,  # FIXME: fix arg passing
                 **kwargs,
             }
 
-            os.environ["HF_HOME"] = download_dir
+            if download_dir:
+                os.environ["HF_HOME"] = download_dir
+                engine_args["download_dir"] = download_dir
+
             if exec_async:
                 engine_args["disable_log_requests"] = kwargs.get("disable_log_requests", False)
                 self.engine = AsyncLLMEngine.from_engine_args(AsyncEngineArgs(**engine_args))


### PR DESCRIPTION
Error occurring with VLLM with cases where download_dir is None. 
When download_dir was None, and we were trying to set it as an environment variable.