### PR TITLE
langchain tutorial

### DIFF
--- a/examples/6_langchain_evaluators.ipynb
+++ b/examples/6_langchain_evaluators.ipynb
@@ -1,0 +1,462 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Flow Judge with Langchain\n",
+    "\n",
+    "## Introduction to Flow Judge and LangChain Integration\n",
+    "\n",
+    "Flow Judge is an open-source language model optimized for evaluating AI systems. This tutorial demonstrates how to integrate Flow Judge with LangChain. By the end of this notebook, you'll understand how to create custom metrics, run evaluations, and analyze results using both Flow Judge and LangChain tools.  \n",
+    "\n",
+    "A key component of this integration is the custom `FlowJudgeLangChainEvaluator` class we created. This class extends LangChain's `StringEvaluator`, allowing Flow Judge to be seamlessly integrated into LangChain workflows. By implementing this custom evaluator, we can use Flow Judge metrics in the same way as LangChain's built-in evaluators, making it easy to incorporate Flow Judge's capabilities into existing LangChain workflows.\n",
+    "\n",
+    "## `Flow-Judge-v0.1`\n",
+    "\n",
+    "`Flow-Judge-v0.1` is an open-source, lightweight (3.8B) language model optimized for LLM system evaluations. Crafted for accuracy, speed, and customization.\n",
+    "\n",
+    "Read the technical report [here](https://www.flow-ai.com/blog/flow-judge).\n",
+    "\n",
+    "\n",
+    "## LangChain evaluators\n",
+    "\n",
+    "LangChain is a powerful framework for developing applications using large language models.\n",
+    "\n",
+    "Refer to the [LangChain evaluation module API reference](https://python.langchain.com/v0.2/api_reference/langchain/evaluation.html#) for more detailed information about their evaluation module.\n",
+    " \n",
+    "LangChain's evaluation module offers built-in evaluators for evaluating the outputs of chains and LLMs. In this notebook, we will demonstrate how to utilize `Flow-Judge-v0.1` custom metrics together with LangChain's framework.\n",
+    "\n",
+    "\n",
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from langchain import LLMChain\n",
+    "except ImportError as e:\n",
+    "    print(\"langchain is not installed. \")\n",
+    "    print(\"Please run `pip install langchain` to install it.\")\n",
+    "    print(\"\\nAfter installation, restart the kernel and run this cell again.\")\n",
+    "    raise SystemExit(f\"Stopping execution due to missing langchain dependency: {e}\")\n",
+    "\n",
+    "try:\n",
+    "    from langchain_openai import ChatOpenAI\n",
+    "except ImportError as e:\n",
+    "    print(\"langchain_openai is not installed. \")\n",
+    "    print(\"Please run `pip install langchain_openai` to install it.\")\n",
+    "    print(\"\\nAfter installation, restart the kernel and run this cell again.\")\n",
+    "    raise SystemExit(f\"Stopping execution due to missing langchain_openai dependency: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# OpenAI API key\n",
+    "\n",
+    "You need to provide an OpenAI API key to use the Langchain evaluators with gpt-4. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-proj-...\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model\n",
+    "\n",
+    "For this tutorial, we are going to use the default VLLM version of `Flow-Judge-v0.1`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/admin/flow-eval-tutorials/flow-judge/flow_judge/models/vllm.py:74: UserWarning: The model 'flowaicom/Flow-Judge-v0.1-AWQ' is not officially supported. This library is designed for the 'flowaicom/Flow-Judge-v0.1' model. Using other models may lead to unexpected behavior, and we do not handle GitHub issues for unsupported models. Proceed with caution.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 10-09 14:24:39 awq_marlin.py:89] The model is convertible to awq_marlin during runtime. Using awq_marlin kernel.\n",
+      "WARNING 10-09 14:24:39 config.py:378] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used\n",
+      "INFO 10-09 14:24:39 llm_engine.py:213] Initializing an LLM engine (v0.6.0) with config: model='flowaicom/Flow-Judge-v0.1-AWQ', speculative_config=None, tokenizer='flowaicom/Flow-Judge-v0.1-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=awq_marlin, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=flowaicom/Flow-Judge-v0.1-AWQ, use_v2_block_manager=False, num_scheduler_steps=1, enable_prefix_caching=False, use_async_output_proc=False)\n",
+      "INFO 10-09 14:24:39 model_runner.py:915] Starting to load model flowaicom/Flow-Judge-v0.1-AWQ...\n",
+      "INFO 10-09 14:24:40 weight_utils.py:236] Using model weights format ['*.safetensors']\n",
+      "INFO 10-09 14:24:40 weight_utils.py:280] No model.safetensors.index.json found in remote.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d1e63f49ad1048349080b1e46dc061a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 10-09 14:24:40 model_runner.py:926] Loading model weights took 2.1861 GB\n",
+      "INFO 10-09 14:24:42 gpu_executor.py:122] # GPU blocks: 2442, # CPU blocks: 682\n"
+     ]
+    }
+   ],
+   "source": [
+    "from flow_judge import Vllm\n",
+    "\n",
+    "model = Vllm()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "We will first create a custom metric for helpfulness. For this example we will use a binary scale to rate the response as helpful or not. Custom metrics can be tailored to evaluate responses based on specific criteria and scoring scales, which makes them a powerful tool for creating use case specific evaluation pipelines. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## QA Evaluations\n",
+    "\n",
+    "In this example, we compare two approaches for evaluating question-answering (QA) responses:\n",
+    "\n",
+    "1. LangChain's Context QA Evaluator\n",
+    "2. Flow-Judge Custom QA Metric\n",
+    "\n",
+    "### LangChain QA Evaluation\n",
+    "\n",
+    "LangChain's built-in \"context_qa\" evaluator provides a binary assessment:\n",
+    "\n",
+    "- Score: 0/1\n",
+    "- Reasoning: CORRECT/INCORRECT\n",
+    "\n",
+    "### Flow-Judge QA Evaluation\n",
+    "\n",
+    "With Flow-Judge we can create custom metrics that offers a more nuanced evaluation. For this example we will create correctness evaluator that will judge the responses on a 1-3 scale. Please refer to the [custom metrics tutorial](2_custom_evaluation_criteria.ipynb) for more examples on how to create custom metrics. \n",
+    "\n",
+    "- Score: 1-3 scale\n",
+    "   - 1: Incorrect or missing most key points\n",
+    "   - 2: Partially correct with some missing information or minor inaccuracies\n",
+    "   - 3: Fully correct and complete\n",
+    "- Reasoning: Detailed explanation of the score and how well the response aligns with the context"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Customer Service QA with Context\n",
+    "\n",
+    "# User Query\n",
+    "query = \"What can I do if I'm not happy with my new TechGadget Pro?\"\n",
+    "\n",
+    "# Context\n",
+    "context = \"\"\"\n",
+    "TechGadget Pro smartphone features:\n",
+    "- 6.5-inch OLED display, 5G capable\n",
+    "- 128GB or 256GB storage\n",
+    "- Triple camera system\n",
+    "- Water-resistant (IP68)\n",
+    "- Price starts at $799\n",
+    "\n",
+    "Return policy: 30-day full refund for undamaged products.\n",
+    "For software issues: Try restarting and updating before contacting support.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Customer Service Response\n",
+    "response = \"\"\"\n",
+    "I understand you're not satisfied with your TechGadget Pro. Here are some options for you:\n",
+    "1. You can return the device within 14 days for a full refund, as long as it's undamaged.\n",
+    "2. If you're experiencing software issues, try restarting the device and check for any available updates.\n",
+    "3. For hardware problems, please visit one of our authorized service centers.\n",
+    "4. We offer a trade-in program if you'd prefer to upgrade to a different model.\n",
+    "Could you tell me more about what specific issues you're facing with the TechGadget Pro?\n",
+    "\"\"\"\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### LangChain's Context QA Evaluator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Score:** 0"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Reasoning:** INCORRECT"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "from langchain.evaluation import load_evaluator \n",
+    "\n",
+    "# Load the langchain evaluator for context qa\n",
+    "qa_evaluator = load_evaluator(\"context_qa\")\n",
+    "\n",
+    "# Evaluate the response\n",
+    "eval_result = qa_evaluator.evaluate_strings(\n",
+    "    prediction=response,\n",
+    "    input=query, \n",
+    "    reference=context # QA evalchain maps the reference as context\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"**Score:** {eval_result[\"score\"]}\"))\n",
+    "display(Markdown(f\"**Reasoning:** {eval_result[\"reasoning\"]}\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This evaluation example of the off-the-shelf LangChain evaluator for QA uses gpt-4 to rate the response. It provides a score of 0 and an reasoning that the response is incorrect. While gpt-4 is a powerful evaluator due to cost and privacy concerns it's not always feasible to use it for evaluations. \n",
+    "\n",
+    "Now let's see how we can use the `FlowJudgeLangChainEvaluator` to achieve the same result by using the flow-judge model to rate the example.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Flow-Judge Custom QA Evaluator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flow_judge import CustomMetric, RubricItem\n",
+    "\n",
+    "correctness_metric = CustomMetric(\n",
+    "    name=\"context_correctness\",\n",
+    "    criteria=\"Evaluate the correctness of the response based on the given context\",\n",
+    "    rubric=[\n",
+    "        RubricItem(score=1, description=\"The response is mostly incorrect or contradicts the information in the context.\"),\n",
+    "        RubricItem(score=2, description=\"The response is partially correct but misses some key information from the context or contains minor inaccuracies.\"),\n",
+    "        RubricItem(score=3, description=\"The response is fully correct and accurately reflects the information provided in the context.\")\n",
+    "    ],\n",
+    "    required_inputs=[\"query\", \"context\"],\n",
+    "    required_output=\"response\" # see note below for output \n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">**Note:** Langchain evaluators typically use the following input variables:\n",
+    "> - `prediction`: The LLM's response (always required)\n",
+    "> - `input`: The user's query (optional)\n",
+    "> - `reference`: The reference answer or context (optional)\n",
+    ">\n",
+    ">Flow Judge Metric Requirements\n",
+    ">Flow Judge metrics have specific required inputs and outputs.\n",
+    ">\n",
+    ">To maintain consistency when using Langchain evaluators with Flow Judge metrics:\n",
+    ">\n",
+    ">1. Always assign the output/response to the `prediction` variable.\n",
+    ">2. The FlowJudgeLangChainEvaluator will automatically map `prediction` to the required output of the metric.\n",
+    ">3. Map other inputs as the metric requires. For example, if the Flow Judge metric requires a `query` and `context` map the values to these keys. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processed prompts: 100%|██████████| 1/1 [00:03<00:00,  3.36s/it, est. speed input: 261.49 toks/s, output: 71.69 toks/s]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Score:** 2"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "**Reasoning:** The response provided by the AI system is mostly correct but contains a significant inaccuracy that affects its overall quality. \n",
+       "\n",
+       "1. The return policy information is incorrect. The context clearly states that the return policy is a 30-day full refund for undamaged products, not 14 days as mentioned in the response. This is a major error as it provides incorrect information to the user.\n",
+       "\n",
+       "2. The advice for software issues is correct and aligns with the context.\n",
+       "\n",
+       "3. The suggestion to visit an authorized service center for hardware problems is not mentioned in the context and seems like an additional service that might not be available.\n",
+       "\n",
+       "4. The trade-in program is not mentioned in the context and appears to be an unsolicited suggestion.\n",
+       "\n",
+       "5. The request for more details about specific issues is appropriate and helpful.\n",
+       "\n",
+       "Overall, while the response contains some correct information and helpful suggestions, the significant error in the return policy information and the inclusion of unmentioned services make it only partially correct."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from flow_judge.integrations.langchain import FlowJudgeLangChainEvaluator \n",
+    "\n",
+    "# Initialize the FlowJudgeLangChainEvaluator with the model and metric\n",
+    "flow_judge_correctness_evaluator = FlowJudgeLangChainEvaluator(model=model, metric=correctness_metric)\n",
+    "\n",
+    "# Evaluate using Flow-Judge evaluator\n",
+    "correctness_result = flow_judge_correctness_evaluator.evaluate_strings(\n",
+    "    query=query,\n",
+    "    context=context,\n",
+    "    prediction=response\n",
+    ")\n",
+    "\n",
+    "display(Markdown(f\"**Score:** {correctness_result[\"score\"]}\"))\n",
+    "display(Markdown(f\"**Reasoning:** {correctness_result[\"reasoning\"]}\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparison\n",
+    "\n",
+    "Both evaluators assessed the correctness of the response in the context of the given query and reference answer. While LangChain provides a straightforward 0/1 judgment, Flow-Judge offers a more granular assessment with its 1-3 scale.\n",
+    "\n",
+    "Key differences:\n",
+    "1. **Scoring granularity**: Flow-Judge's 3-point scale allows for more nuanced feedback compared to LangChain's binary output. This is fully customizable so you can choose the scoring granularity that best fits your use case.\n",
+    "2. **Reasoning detail**: Flow-Judge provides comprehensive explanations, which can be valuable for understanding subtle quality differences between responses.\n",
+    "3. **Customization**: The Flow-Judge metric can be easily adjusted to focus on specific aspects of QA performance, offering flexibility for various use cases.\n",
+    "\n",
+    "This comparison demonstrates how Flow-Judge can provide more detailed insights into response quality, which can be particularly useful for fine-tuning QA systems or conducting in-depth analyses of model outputs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this notebook, we explored how Flow Judge can work alongside LangChain for evaluating LLM responses. Here are the key takeaways:\n",
+    "\n",
+    "1. Custom metrics: We created tailored evaluation criteria using Flow Judge.\n",
+    "2. Integration: The `FlowJudgeLangChainEvaluator` class lets us use Flow Judge within LangChain workflows.\n",
+    "3. Comparison: We saw how Flow Judge's approach offers more detailed insights compared to LangChain's built-in evaluators.\n",
+    "\n",
+    "Benefits of using Flow Judge with LangChain:\n",
+    "- More customizable evaluation metrics\n",
+    "- Granular feedback on model outputs\n",
+    "- Easy integration with existing LangChain projects\n",
+    "\n",
+    "Overall, this combo gives you flexibility and power when assessing LLM-generated responses."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "flow-eval-tutorials",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/flow_judge/integrations/langchain.py
+++ b/flow_judge/integrations/langchain.py
@@ -1,0 +1,121 @@
+import asyncio
+from collections.abc import Sequence
+from typing import Any
+
+from langchain.evaluation import StringEvaluator
+
+from flow_judge import AsyncFlowJudge, EvalInput, FlowJudge
+from flow_judge.metrics import CustomMetric, Metric
+from flow_judge.models import AsyncBaseFlowJudgeModel, BaseFlowJudgeModel
+
+
+class FlowJudgeLangChainEvaluator(StringEvaluator):
+    """FlowJudgeLangchainEvaluator is a custom evaluator for LangChain.
+
+    It uses FlowJudge to evaluate the LLM outputs.
+    """
+
+    def __init__(
+        self, metric: Metric | CustomMetric, model: BaseFlowJudgeModel | AsyncBaseFlowJudgeModel
+    ):
+        """Initialize the LlamaIndexFlowJudge."""
+        if isinstance(metric, (Metric, CustomMetric)):
+            self.metric = metric
+        else:
+            raise ValueError("Invalid metric type. Use Metric or CustomMetric.")
+
+        # Validate model and choose appropriate FlowJudge class
+        if isinstance(model, (BaseFlowJudgeModel, AsyncBaseFlowJudgeModel)):
+            self.model = model
+        else:
+            raise ValueError(
+                "The model must be an instance of BaseFlowJudgeModel or AsyncBaseFlowJudgeModel."
+            )
+
+        # Determine if the model is async-capable
+        self.is_async = hasattr(self.model, "exec_async") and self.model.exec_async
+
+        # Initialize the appropriate judge based on async capability
+        if self.is_async:
+            self.judge = AsyncFlowJudge(metric=self.metric, model=self.model)
+        else:
+            self.judge = FlowJudge(metric=self.metric, model=self.model)
+
+    def _prepare_eval_input(
+        self,
+        prediction: str,
+        reference: str | None = None,
+        input: str | None = None,
+        **kwargs: Any,
+    ) -> EvalInput:
+        # Combine all inputs into a single dictionary
+        all_inputs = {"prediction": prediction, "reference": reference, "input": input, **kwargs}
+
+        # Prepare eval_inputs based on metric's required_inputs
+        eval_inputs = []
+        for req_input in self.metric.required_inputs:
+            if req_input in all_inputs:
+                value = all_inputs[req_input]
+                if isinstance(value, (list, Sequence)) and not isinstance(value, str):
+                    eval_inputs.extend([{req_input: v} for v in value])
+                else:
+                    eval_inputs.append({req_input: value})
+
+        # Prepare the output
+        output_key = self.metric.required_output
+        output_value = all_inputs.get(
+            output_key, prediction
+        )  # Default to prediction if not specified
+
+        return EvalInput(inputs=eval_inputs, output={output_key: output_value})
+
+    def _evaluate_strings(
+        self,
+        prediction: str,
+        reference: str | None = None,
+        input: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        eval_input = self._prepare_eval_input(prediction, reference, input, **kwargs)
+        result = self.judge.evaluate(eval_input, save_results=False)
+
+        return {
+            "score": result.score,
+            "reasoning": result.feedback,
+        }
+
+    async def _aevaluate_strings(
+        self,
+        prediction: str,
+        reference: str | None = None,
+        input: str | None = None,
+        sleep_time_in_seconds: int = 1,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        await asyncio.sleep(sleep_time_in_seconds)
+        eval_input = self._prepare_eval_input(prediction, reference, input, **kwargs)
+        result = await self.judge.async_evaluate(eval_input, save_results=False)
+
+        return {
+            "score": result.score,
+            "reasoning": result.feedback,
+        }
+
+    @property
+    def requires_input(self) -> bool:
+        """Requires input."""
+        return "input" in self.metric.required_inputs
+
+    @property
+    def requires_reference(self) -> bool:
+        """Requires reference."""
+        return "reference" in self.metric.required_inputs
+
+    @property
+    def evaluation_name(self) -> str:
+        """Get metric name."""
+        return f"flow_judge_{self.metric.name}"
+
+    def get_required_inputs(self) -> list[str]:
+        """Get required inputs."""
+        return self.metric.required_inputs + [self.metric.required_output]


### PR DESCRIPTION
# LangChain Integration for Flow Judge

## Summary
This PR introduces an integration between Flow Judge and LangChain, allowing users to leverage Flow Judge's custom metrics within LangChain workflows.

## Key Changes
1. Created `FlowJudgeLangChainEvaluator` class on the integrations folder: 
   - Extends LangChain's `StringEvaluator`
   - Enables use of Flow Judge metrics in LangChain pipelines

2. Added example notebook:
   - Demonstrates usage of Flow Judge integration within LangChain
   - Compares Flow Judge custom metrics with LangChain's built-in evaluators

## Testing
The integration has been manually tested: 
-  On linux Ubuntu 22.04.3 LTS 
- Verified functionality of `FlowJudgeLangChainEvaluator` with models Flow-Judge-v0.1-AWQ, Flow-Judge-v0.1, Flow-Judge-v0.1_HF and Flow-Judge-v0.1-AWQ-Async ( note Async functionality is not demonstrated in the notebook, but it was part of the standard stringevaluator class, so I added the option as well) 
- Verified functionality of `FlowJudgeLangChainEvaluator` with custom metric (in notebook), and built-in metrics (metric=RESPONSE_CORRECTNESS_BINARY, model=model)
- Tested integration in example notebook, ensuring correct behaviour within LangChain workflows
- Manually viewed results with LangChain's native evaluators to confirm accuracy and consistency