### PR TITLE
Chore: update Baseten example with proxy links

### DIFF
--- a/examples/7_baseten_async_quickstart.ipynb
+++ b/examples/7_baseten_async_quickstart.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Quickstart\n",
     "\n",
-    "This tutorial demonstrates how to use the `Baseten` model class in async mode to perform language model-based evaluations using Flow-Judge-v0.1 deployed model on Baseten."
+    "This tutorial demonstrates how to use the `Baseten` model class in async mode to perform language model-based evaluations using Flow-Judge-v0.1 deployed model on Baseten. For detailed instructions on how to use Baseten, visit the [Baseten readme](https://github.com/flowaicom/flow-judge/blob/main/flow_judge/models/adapters/baseten/README.md)."
    ]
   },
   {
@@ -15,7 +15,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "Let's instantiate the `Baseten` model class in async mode. The async implementation makes use Baseten's async inference approach. See [here](https://docs.baseten.co/invoke/async).\n",
+    "Let's instantiate the `Baseten` model class in async mode. The async implementation makes use of Baseten's async inference approach. See [here](https://docs.baseten.co/invoke/async).\n",
     "\n",
     "You can imagine this as *fire-and-forget* functionality. Completion requests are made to the deployed model, once data is processed and inference is complete, the output is sent to a predefined webhook. The webhook url is part of the original request. The `Flow-Judge` library then connects with the webhook and *listens* for a response. The library makes use of this approach to allow configurability for concurrent execution.\n",
     "\n",
@@ -64,7 +64,7 @@
     "\n",
     "Set the following required options for async execution mode of the Baseten model class: \n",
     "1. `exec_async=True`\n",
-    "2. `webhook_proxy_url=https://proxy.flow-ai.dev` (or an alternative)\n",
+    "2. `webhook_proxy_url=https://proxy.flow-ai.dev` (or [run the proxy locally](https://github.com/flowaicom/flow-judge/blob/main/flow_judge/models/adapters/baseten/README.md))\n",
     "\n",
     "Optionally you can set the `async_batch_size` option to a value > 0 (defaults to `128`). This is the number of concurrent requests sent to the deployed model. It is associated with the concurrency goals you want to achieve and can be actively configured in Baseten's UI. For more information, see [here](https://docs.baseten.co/performance/concurrency). Our current deployment configuration allows a concurrency target of `128` and max replica of `1` for the deployed model as the default on Baseten. This means if you have max replica set to 1 on Baseten, it can accept concurrent requests of `128`. The batch size you set for the Baseten model class should be equivalent to the number of `concurrency_target * number_of_replicas`"
    ]
@@ -100,7 +100,7 @@
     "\n",
     "Let's test batched evaluations with our example csr data on the faithfulness 5 point likert.\n",
     "\n",
-    "We use the `async_batch_evaluate` method from the FlowJudge class. Underneath this uses batched processing utilizing the batch_size set with the `async_batch_size` argument of the Baseten model class. If there are failures, for example with networking, the batch will process and errors will be propagated as log outputs. The output would include the successful responses."
+    "We use the `async_batch_evaluate` method from the AsyncFlowJudge class. Underneath this uses batched processing utilizing the batch_size set with the `async_batch_size` argument of the Baseten model class. If there are failures, for example with networking, the batch will process and errors will be propagated as log outputs. The output would include the successful responses."
    ]
   },
   {


### PR DESCRIPTION
Just a quick update to the Baseten async example notebook. Adding:
- Baseten readme link
- Proxy link
- A few grammatical fixes